### PR TITLE
Revert "Prefix style" commit

### DIFF
--- a/json-form/package.json
+++ b/json-form/package.json
@@ -21,7 +21,6 @@
   },
   "devDependencies": {
     "@types/carbon-components-react": "^7.25.2",
-    "@types/carbon-components": "^10.27.1",
     "@types/carbon__icons-react": "^10.23.0",
     "@types/jest": "^26.0.20",
     "@types/react": "^16.9.56",

--- a/json-form/src/JsonEditor.scss
+++ b/json-form/src/JsonEditor.scss
@@ -15,7 +15,6 @@
  */
 
 // Carbon theme
-$prefix: 'djson';
 @import '~carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/themes/theme-maps';
 $carbon--theme: $carbon--theme--g10;
 @import '~carbon-components/scss/globals/scss/typography';
@@ -114,7 +113,7 @@ $carbon--theme: $carbon--theme--g10;
     padding: 8px;
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
 
-    .#{$prefix}--text-input {
+    .bx--text-input {
       min-width: 330px;
     }
 
@@ -149,10 +148,10 @@ $carbon--theme: $carbon--theme--g10;
         margin-top: 8px;
       }
 
-      .#{$prefix}--tag {
+      .bx--tag {
         margin: 0 8px 0 0;
 
-        &.#{$prefix}--tag--interactive {
+        &.bx--tag--interactive {
           background-color: #d0e2ff;
           color: #002d9c;
 
@@ -205,13 +204,13 @@ $carbon--theme: $carbon--theme--g10;
     }
   }
 
-  .#{$prefix}--date-picker {
+  .bx--date-picker {
     width: 100%;
 
-    .#{$prefix}--date-picker-container {
+    .bx--date-picker-container {
       width: 100%;
 
-      .#{$prefix}--date-picker__input.flatpickr-input {
+      .bx--date-picker__input.flatpickr-input {
         width: 100%;
       }
     }
@@ -221,15 +220,15 @@ $carbon--theme: $carbon--theme--g10;
     display: flex;
     width: 100%;
 
-    .#{$prefix}--time-picker__input {
+    .bx--time-picker__input {
       flex-grow: 1;
 
-      .#{$prefix}--text-input.time-picker {
+      .bx--text-input.time-picker {
         //text-align: right;
       }
     }
 
-    .#{$prefix}--select-input {
+    .bx--select-input {
       margin-left: 8px;
       height: 2.3rem;
     }

--- a/json-form/src/JsonEditor.tsx
+++ b/json-form/src/JsonEditor.tsx
@@ -13,8 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { settings } from 'carbon-components';
-settings.prefix = 'djson';
+
 import React from 'react';
 import {
   Cmd,

--- a/webtests/helpers/src/main/java/diesel/json/FDate.java
+++ b/webtests/helpers/src/main/java/diesel/json/FDate.java
@@ -18,12 +18,12 @@ public class FDate extends FJsonValue{
         return this;
     }
     public FDate assertNoError() {
-        $$(".djson--form-requirement").count(0).eval();
+        $$(".bx--form-requirement").count(0).eval();
         findInput().where(not(attrEquals("data-invalid", "true"))).eval();
         return this;
     }
     public FDate assertHasError(String expectedError){
-        $$(".djson--form-requirement")
+        $$(".bx--form-requirement")
                 .at(0)
                 .where(textEquals(expectedError)).eval();
         return this;

--- a/webtests/helpers/src/main/java/diesel/json/FJsonForm.java
+++ b/webtests/helpers/src/main/java/diesel/json/FJsonForm.java
@@ -56,7 +56,7 @@ public class FJsonForm extends AbstractPageObject {
     }
 
     public FMenu clickRootMenu() {
-        $$(".doc-root button.djson--tooltip__trigger")
+        $$(".doc-root button.bx--tooltip__trigger")
             .expectOne()
             .click();
         return new FMenu(fRoot);

--- a/webtests/helpers/src/main/java/diesel/json/FNumber.java
+++ b/webtests/helpers/src/main/java/diesel/json/FNumber.java
@@ -20,13 +20,13 @@ public class FNumber extends FJsonValue {
     }
 
     public FNumber assertHasError() {
-        $$(".djson--form-requirement").count(0).eval();
+        $$(".bx--form-requirement").count(0).eval();
         findInput().where((attrEquals("data-invalid", "true"))).eval();
         return this;
     }
 
     public FNumber assertNoError() {
-        $$(".djson--form-requirement").count(0).eval();
+        $$(".bx--form-requirement").count(0).eval();
         findInput().where(not(attrEquals("data-invalid", "true"))).eval();
         return this;
     }

--- a/webtests/helpers/src/main/java/diesel/json/FObject.java
+++ b/webtests/helpers/src/main/java/diesel/json/FObject.java
@@ -129,11 +129,11 @@ public class FObject extends FJsonValue {
     }
     public FObject selectPropertyValue(String property, String value){
         Findr findSelect = findPropRow(property)
-                 .$$(".djson--list-box__menu-icon")
+                 .$$(".bx--list-box__menu-icon")
                  .expectOne();
 
         findSelect.click();
-        $$(".djson--list-box__menu-item__option")
+        $$(".bx--list-box__menu-item__option")
                 .where(Findrs.textEquals(value))
                 .expectOne()
                 .click();

--- a/webtests/helpers/src/main/java/diesel/json/FString.java
+++ b/webtests/helpers/src/main/java/diesel/json/FString.java
@@ -26,13 +26,13 @@ public class FString extends FJsonValue {
     }
 
     public FString assertNoError() {
-        $$(".djson--form-requirement").count(0).eval();
+        $$(".bx--form-requirement").count(0).eval();
         findInput().where(not(attrEquals("data-invalid", "true"))).eval();
         return this;
     }
 
     public FString assertError(String expectedError) {
-        $$(".djson--form-requirement")
+        $$(".bx--form-requirement")
                 .where(textContains(expectedError))
                 .count(1)
                 .at(0)

--- a/webtests/helpers/src/main/java/diesel/json/FTime.java
+++ b/webtests/helpers/src/main/java/diesel/json/FTime.java
@@ -18,12 +18,12 @@ public class FTime extends FJsonValue{
         return this;
     }
     public FTime assertNoError() {
-        $$(".djson--form-requirement").count(0).eval();
+        $$(".bx--form-requirement").count(0).eval();
         findInput().where(not(attrEquals("data-invalid", "true"))).eval();
         return this;
     }
     public FTime assertHasError(String expectedError){
-        $$(".djson--form-requirement")
+        $$(".bx--form-requirement")
                 .at(0)
                 .where(textEquals(expectedError)).eval();
         return this;

--- a/yarn.lock
+++ b/yarn.lock
@@ -694,11 +694,6 @@
     "@types/react" "*"
     flatpickr "4.6.1"
 
-"@types/carbon-components@^10.27.1":
-  version "10.27.3"
-  resolved "https://registry.yarnpkg.com/@types/carbon-components/-/carbon-components-10.27.3.tgz#2c092b36de6d46d808e468eb31e0f693a2c0ed60"
-  integrity sha512-C4oDSXYFyPZa5ZM2pxBHcjzOuI/OP3whuCt2WzabxssaZHymOHjcaP1lXERkIfswLoNrAeSKfKad0wIeQbzNUA==
-
 "@types/carbon__icons-react@^10.23.0":
   version "10.31.1"
   resolved "https://registry.npmjs.org/@types/carbon__icons-react/-/carbon__icons-react-10.31.1.tgz"


### PR DESCRIPTION
This reverts commit e398ab46fed49b9f93c0d0922b78cd183884854c.

It does not behave as expected in consumer app and style overwriting is even worse. 
Let's wait for Carbon v11 to get [new helper hook](https://stackblitz.com/github/carbon-design-system/carbon/tree/main/examples/class-prefix?file=src%2FApp.jsx) to easily define a custom prefix.