### PR TITLE
Fix combobox not editable

### DIFF
--- a/json-form/src/renderer/Renderer.tsx
+++ b/json-form/src/renderer/Renderer.tsx
@@ -504,6 +504,12 @@ function ViewStringWithCombo(p: ViewStringWithComboProps): React.ReactElement {
           value: item.selectedItem ?? '',
         });
       }}
+      onInputChange={(text) => {
+        dispatchUpdateProperty(p, {
+          tag: 'jv-string',
+          value: text ?? '',
+        });
+      }}
     />
   );
 }


### PR DESCRIPTION
Listen to `onInputChange` in order to change the value even if no item is selected in the combo.