### PR TITLE
Fix UX for "cleared" numbers

### DIFF
--- a/json-form/src/Msg.ts
+++ b/json-form/src/Msg.ts
@@ -99,6 +99,7 @@ export interface DeleteProperty extends HasPath {
 export interface UpdateProperty extends HasPath {
   tag: 'update-property';
   value: JsonValue;
+  selectText?: boolean;
 }
 
 export interface AddPropertyClicked extends HasPath {

--- a/json-form/src/renderer/Renderer.tsx
+++ b/json-form/src/renderer/Renderer.tsx
@@ -397,11 +397,13 @@ function ViewArray(p: ViewValueProps<JvArray>): React.ReactElement {
 function dispatchUpdateProperty(
   p: ViewValueProps<JsonValue>,
   newValue: JsonValue,
+  selectText?: boolean,
 ) {
   p.dispatch({
     tag: 'update-property',
     path: p.path,
     value: newValue,
+    selectText,
   });
 }
 
@@ -419,10 +421,16 @@ function ViewNumber(p: ViewValueProps<JvNumber>): React.ReactElement {
       invalid={isInvalid(p)}
       onChange={(evt) => {
         let newValue = parseFloat(evt.target.value);
+        let selectText = false;
         if (isNaN(newValue)) {
           newValue = 0;
+          selectText = true;
         }
-        dispatchUpdateProperty(p, { tag: 'jv-number', value: newValue });
+        dispatchUpdateProperty(
+          p,
+          { tag: 'jv-number', value: newValue },
+          selectText,
+        );
       }}
     />
   );


### PR DESCRIPTION
Select all text when a numeric field is "cleared", and its value is reset to zero.

![select when cleared to zero](https://github.com/IBM/diesel-json-form/assets/454850/79d41cca-073b-4553-a731-24a9681da4e9)
