### PR TITLE
Fixes to path, add tests

### DIFF
--- a/json-form/src/JsPath.test.ts
+++ b/json-form/src/JsPath.test.ts
@@ -42,6 +42,13 @@ describe('JsPath', () => {
     expect(JsPath.parse('foo').parent()).toEqual(just(JsPath.empty));
     expect(JsPath.parse('foo/bar').parent()).toEqual(just(JsPath.parse('foo')));
   });
+  test('is parent of', () => {
+    expect(JsPath.empty.isParentOf(JsPath.empty)).toBe(false);
+    expect(JsPath.parse('foo').isParentOf(JsPath.parse('foo'))).toBe(false);
+    expect(JsPath.parse('foo').isParentOf(JsPath.parse('foo/bar'))).toBe(true);
+    expect(JsPath.parse('foo/bar').isParentOf(JsPath.parse('foo'))).toBe(false);
+    expect(JsPath.parse('foo').isParentOf(JsPath.parse('bar'))).toBe(false);
+  });
   test('leading slash throws', () => {
     expect(() => JsPath.parse('/')).toThrowError(
       "Invalid path : /, leading slash isn't allowed",

--- a/json-form/src/JsPath.test.ts
+++ b/json-form/src/JsPath.test.ts
@@ -15,11 +15,32 @@
  */
 
 import { describe, test, expect } from 'vitest';
-import { JsPath } from './JsPath';
+import { containsNonEscapedSlash, JsPath } from './JsPath';
+import { just, nothing } from 'tea-cup-fp';
 
 describe('JsPath', () => {
   test('empty', () => {
     expect(JsPath.parse('')).toEqual(JsPath.empty);
+    expect(JsPath.empty.isEmpty()).toBe(true);
+    expect(JsPath.empty.elems).toEqual([]);
+    expect(JsPath.empty.format()).toEqual('');
+    expect(JsPath.empty.equals(JsPath.empty)).toBe(true);
+  });
+  test('not empty', () => {
+    expect(JsPath.parse('foo').isEmpty()).toBe(false);
+  });
+  test('head/tail', () => {
+    expect(JsPath.empty.head()).toEqual(nothing);
+    expect(JsPath.empty.tail()).toEqual(JsPath.empty);
+    expect(JsPath.parse('foo').head()).toEqual(just('foo'));
+    expect(JsPath.parse('foo').tail()).toEqual(JsPath.empty);
+    expect(JsPath.parse('foo/bar/baz').head()).toEqual(just('foo'));
+    expect(JsPath.parse('foo/bar/baz').tail()).toEqual(JsPath.parse('bar/baz'));
+  });
+  test('parent', () => {
+    expect(JsPath.empty.parent()).toEqual(nothing);
+    expect(JsPath.parse('foo').parent()).toEqual(just(JsPath.empty));
+    expect(JsPath.parse('foo/bar').parent()).toEqual(just(JsPath.parse('foo')));
   });
   test('leading slash throws', () => {
     expect(() => JsPath.parse('/')).toThrowError(
@@ -30,5 +51,35 @@ describe('JsPath', () => {
     expect(() => JsPath.parse('/yalla')).toThrowError(
       "Invalid path : /yalla, leading slash isn't allowed",
     );
+  });
+  test('trailing slash throws', () => {
+    expect(() => JsPath.parse('foo/')).toThrowError(
+      "Invalid path : foo/, trailing slash isn't allowed",
+    );
+  });
+  test('trailing slash throws 2', () => {
+    expect(() => JsPath.parse('foo/bar/')).toThrowError(
+      "Invalid path : foo/bar/, trailing slash isn't allowed",
+    );
+  });
+  test('cannot append elem with slash', () => {
+    expect(() => JsPath.empty.append('yo/lo')).toThrowError(
+      'Invalid path element : yo/lo, contains non-escaped slash',
+    );
+  });
+});
+
+describe('contains non escaped slash', () => {
+  test('no slashes', () => {
+    expect(containsNonEscapedSlash('yolo')).toBe(false);
+  });
+  test('one slash', () => {
+    expect(containsNonEscapedSlash('yo/lo')).toBe(true);
+  });
+  test('one escaped slash', () => {
+    expect(containsNonEscapedSlash('yo\\/lo')).toBe(false);
+  });
+  test('one escaped, one not', () => {
+    expect(containsNonEscapedSlash('yo\\/lo/lo')).toBe(true);
   });
 });

--- a/json-form/src/JsPath.ts
+++ b/json-form/src/JsPath.ts
@@ -45,6 +45,9 @@ export class JsPath {
   }
 
   append(elem: string | number): JsPath {
+    if (typeof elem === 'string' && containsNonEscapedSlash(elem)) {
+      throw `Invalid path element : ${elem}, contains non-escaped slash`;
+    }
     return new JsPath(this._elems.concat([elem.toString()]));
   }
 
@@ -61,7 +64,9 @@ export class JsPath {
   }
 
   isParentOf(child: JsPath): boolean {
-    return child.format().startsWith(this.format());
+    const childFmt = child.format();
+    const thisFmt = this.format();
+    return childFmt !== thisFmt && childFmt.startsWith(thisFmt);
   }
 
   static parse(path: string) {
@@ -71,9 +76,26 @@ export class JsPath {
     if (path.startsWith('/')) {
       throw 'Invalid path : ' + path + ", leading slash isn't allowed";
     }
+    if (path.endsWith('/')) {
+      throw 'Invalid path : ' + path + ", trailing slash isn't allowed";
+    }
     const parts = path.split('/');
     return new JsPath(parts);
   }
 
   static empty: JsPath = new JsPath([]);
+}
+
+export function containsNonEscapedSlash(s: string): boolean {
+  const i = s.indexOf('/');
+  if (i !== -1) {
+    const head = s.substring(0, i);
+    if (!head.endsWith('\\')) {
+      return true;
+    }
+    const tail = s.substring(i + 1);
+    return containsNonEscapedSlash(tail);
+  } else {
+    return false;
+  }
 }


### PR DESCRIPTION
Throw if create paths with trailing slashes
Throw if add path elem that contain non escaped slashes
Fix isParentOf()